### PR TITLE
Implement  a Simple Tensor Class for Flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Load a model and make predictions
 
 ```php
 $model = new OnnxRuntime\Model('model.onnx');
-$model->predict(['x' => [1, 2, 3]]);
+$x = OnnxRuntime\Tensor::fromArray([1, 2, 3]]);
+$model->predict(['x' => $x);
 ```
 
 > Download pre-trained models from the [ONNX Model Zoo](https://github.com/onnx/models)
@@ -59,7 +60,8 @@ $model = new OnnxRuntime\Model($stream);
 Get specific outputs
 
 ```php
-$model->predict(['x' => [1, 2, 3]], outputNames: ['label']);
+$x = OnnxRuntime\Tensor::fromArray([1, 2, 3]);
+$model->predict(['x' => $x], outputNames: ['label']);
 ```
 
 ## Session Options
@@ -107,7 +109,8 @@ You can also use the Inference Session API, which follows the [Python API](https
 
 ```php
 $session = new OnnxRuntime\InferenceSession('model.onnx');
-$session->run(null, ['x' => [1, 2, 3]]);
+$x = OnnxRuntime\Tensor::fromArray([1, 2, 3]);
+$session->run(null, ['x' => $x]);
 ```
 
 The Python example models are included as well.

--- a/src/DType.php
+++ b/src/DType.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace OnnxRuntime;
+
+enum DType
+{
+    case Bool;
+    case Int8;
+    case Int16;
+    case Int32;
+    case Int64;
+    case Uint8;
+    case Uint16;
+    case Uint32;
+    case Uint64;
+    case Float8;
+    case Float16;
+    case Float32;
+    case Float64;
+    case String;
+    case Complex64;
+    case Complex128;
+    case BFloat16;
+
+
+    public function packFormat(): string
+    {
+        return match ($this) {
+            DType::Bool => 'C*',
+            DType::Int8 => 'c*',
+            DType::Int16 => 's*',
+            DType::Int32 => 'l*',
+            DType::Int64 => 'q*',
+            DType::Uint8 => 'C*',
+            DType::Uint16 => 'S*',
+            DType::Uint32 => 'L*',
+            DType::Uint64 => 'Q*',
+            DType::Float8 => 'C*',
+            DType::Float16 => 'S*',
+            DType::Float32 => 'g*',
+            DType::Float64 => 'e*',
+            DType::String => 'a*',
+        };
+    }
+
+    public static function inferFrom(mixed $value): self
+    {
+        return match (true) {
+            is_bool($value) => self::Bool,
+            is_int($value) => self::Int32,
+            is_float($value) => self::Float64,
+            is_string($value) => self::String,
+            default => throw new \InvalidArgumentException('Unsupported data type'),
+        };
+    }
+
+    public function castValue(mixed $value): string|int|bool|float
+    {
+        return match ($this) {
+            DType::Bool => (bool)$value,
+            DType::Int8 => (int)$value,
+            DType::Int16 => (int)$value,
+            DType::Int32 => (int)$value,
+            DType::Int64 => (int)$value,
+            DType::Uint8 => (int)$value,
+            DType::Uint16 => (int)$value,
+            DType::Uint32 => (int)$value,
+            DType::Uint64 => (int)$value,
+            DType::Float8 => (float)$value,
+            DType::Float16 => (float)$value,
+            DType::Float32 => (float)$value,
+            DType::Float64 => (float)$value,
+            DType::String => (string)$value,
+            self::Complex64,
+            self::Complex128,
+            self::BFloat16 => throw new \Exception('To be implemented'),
+        };
+    }
+}

--- a/src/InferenceSession.php
+++ b/src/InferenceSession.php
@@ -332,7 +332,7 @@ class InferenceSession
 
         $idx = 0;
 
-        /** @var Tensor $input */
+        /** @var TensorInterface $input */
         foreach ($inputFeed as $inputName => $input) {
             // TODO support more types
             $inp = null;
@@ -397,7 +397,7 @@ class InferenceSession
         return $inputTensor;
     }
 
-    private function fillStringTensorValues(Tensor $input, $ptr, &$refs): void
+    private function fillStringTensorValues(TensorInterface $input, $ptr, &$refs): void
     {
         foreach ($input->buffer() as $i => $v) {
             $strPtr = $this->cstring($v);

--- a/src/Tensor.php
+++ b/src/Tensor.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OnnxRuntime;
+
+use EmptyIterator;
+use InvalidArgumentException;
+use OutOfBoundsException;
+use RuntimeException;
+use SplFixedArray;
+use Traversable;
+
+class Tensor implements TensorInterface
+{
+    /**
+     * Construct a new Tensor instance.
+     *
+     * @param SplFixedArray $buffer A flat buffer containing tensor data.
+     * @param array $shape The shape of the tensor.
+     * @param DType $dtype The data type of the tensor.
+     */
+    public function __construct(
+        protected SplFixedArray $buffer,
+        protected array         $shape,
+        protected DType         $dtype,
+    )
+    {
+    }
+
+    /**
+     * Create a Tensor instance from a PHP array.
+     *
+     * @param array $array The input array.
+     * @param DType|null $dtype The data type of the tensor (optional).
+     * @param array|null $shape The shape of the tensor (optional).
+     * @return static The created Tensor instance.
+     * @throws InvalidArgumentException If the shape isn't provided when the array is empty.
+     */
+    public static function fromArray(array $array, ?DType $dtype = null, ?array $shape = null): static
+    {
+        if (empty($array) && $shape === null) {
+            throw new InvalidArgumentException('Shape must be provided when the array is empty');
+        }
+
+        $shape ??= self::generateShape($array);
+
+        $buffer = new SplFixedArray(array_product($shape));
+
+        $index = 0;
+
+        self::flattenArray($array, $buffer, $index, $dtype);
+
+        return new static($buffer, $shape, $dtype);
+    }
+
+    /**
+     * Create a Tensor instance from a packed binary string.
+     *
+     * @param string $string The packed binary string containing the tensor data (flat)
+     * @param DType $dtype The data type of the tensor.
+     * @param array $shape The shape of the tensor.
+     * @return static The created Tensor instance.
+     * @throws RuntimeException If an error occurs during string unpacking.
+     * @throws InvalidArgumentException If the number of elements in the string does not match the shape.
+     */
+    public static function fromString(string $string, DType $dtype, array $shape): static
+    {
+        $data = unpack($dtype->packFormat(), $string);
+
+        if ($data === false) {
+            throw new RuntimeException('Error unpacking string data');
+        }
+
+        if (count($data) != array_product($shape)) {
+            throw new InvalidArgumentException('The number of elements in the string does not match the shape');
+        }
+
+        $i = 0;
+
+        $buffer = new SplFixedArray(array_product($shape));
+
+        foreach ($data as $value) {
+            $buffer[$i++] = $dtype->castValue($value);
+        }
+
+        return new static($buffer, $shape, $dtype);
+    }
+
+    /**
+     * Get the shape of the tensor.
+     *
+     * @return array The shape of the tensor.
+     */
+    public function shape(): array
+    {
+        return $this->shape;
+    }
+
+    /**
+     * Get the number of dimensions of the tensor.
+     *
+     * @return int The number of dimensions of the tensor.
+     */
+    public function ndim(): int
+    {
+        return count($this->shape);
+    }
+
+    /**
+     * Get the data type of the tensor.
+     *
+     * @return DType The data type of the tensor.
+     */
+    public function dtype(): DType
+    {
+        return $this->dtype;
+    }
+
+    public function buffer(): SplFixedArray
+    {
+        return $this->buffer;
+    }
+
+    public function size(): int
+    {
+        return array_product($this->shape);
+    }
+
+    public function reshape(array $shape): static
+    {
+        if (array_product($shape) != array_product($this->shape)) {
+            throw new InvalidArgumentException('New shape must have the same number of elements');
+        }
+
+        return new static($this->buffer, $shape, $this->dtype);
+    }
+
+    public function toArray(): array
+    {
+        $i = 0;
+        return self::unflattenArray($this->buffer, $this->shape, $i);
+    }
+
+    public function toString(): string
+    {
+        $string = '';
+
+        foreach ($this->buffer as $value) {
+            $string .= pack($this->dtype->packFormat(), $value);
+        }
+
+        return $string;
+    }
+
+    public function count(): int
+    {
+        return $this->shape[0];
+    }
+
+    public static function generateShape(array $array): array
+    {
+        $shape = [];
+
+        while (is_array($array)) {
+            $shape[] = count($array);
+            $array = reset($array);
+        }
+
+        return $shape;
+    }
+
+    public static function flattenArray($nestedArray, SplFixedArray $buffer, int &$index, ?DType $dtype): void
+    {
+        foreach ($nestedArray as $value) {
+            if (is_array($value)) {
+                self::flattenArray($value, $buffer, $index, $dtype);
+            } else {
+                $dtype ??= DType::inferFrom($value);
+                $buffer[$index++] = $dtype->castValue($value);
+            }
+        }
+    }
+
+    public static function unflattenArray(SplFixedArray $buffer, array $shape, int &$index): array
+    {
+        if (array_product($shape) == 0)
+            return [];
+
+        $nestedArray = [];
+        $size = array_shift($shape);
+
+        for ($i = 0; $i < $size; $i++) {
+            if (empty($shape)) {
+                $nestedArray[] = $buffer[$index++];
+            } else {
+                $nestedArray[] = self::unflattenArray($buffer, $shape, $index);
+            }
+        }
+
+        return $nestedArray;
+    }
+
+    public function getIterator(): Traversable
+    {
+        if (count($this->shape) == 0)
+            return new EmptyIterator();
+
+        $count = $this->count();
+
+        for ($i = 0; $i < $count; $i++) {
+            yield $i => $this->offsetGet($i);
+        }
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        if (count($this->shape) == 0)
+            return false;
+
+        return $offset >= 0 && $offset < $this->shape[0];
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        if (!$this->offsetExists($offset)) {
+            throw new OutOfBoundsException('Index out of bounds');
+        }
+
+        $shape = $this->shape;
+
+        if (count($shape) == 1) {
+            return $this->buffer[$offset];
+        }
+
+        $newShape = array_slice($shape, 1);
+        $newSize = array_product($newShape);
+
+        $buffer = new SplFixedArray($newSize);
+
+        for ($i = 0; $i < $newSize; $i++) {
+            $buffer[$i] = $this->buffer[$offset * $newSize + $i];
+        }
+
+        return new self($buffer, $newShape, $this->dtype);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        if (!$this->offsetExists($offset)) {
+            throw new OutOfBoundsException('Index out of bounds');
+        }
+
+        $shape = $this->shape;
+
+        if (!count($shape)) {
+            if (!is_scalar($value))
+                throw new InvalidArgumentException("Must be scalar type");
+
+            $this->buffer[$offset] = $value;
+            return;
+        }
+
+        if (!($value instanceof self) || $value->shape() != $shape) {
+            throw new InvalidArgumentException('Value must be a tensor with the same shape');
+        }
+
+        $buffer = $value->buffer();
+        $size = array_product($shape);
+
+        for ($i = 0; $i < $size; $i++) {
+            $this->buffer[$offset * $size + $i] = $buffer[$i];
+        }
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new RuntimeException('Cannot unset tensor elements');
+    }
+}

--- a/src/TensorInterface.php
+++ b/src/TensorInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OnnxRuntime;
+
+use ArrayAccess;
+use Countable;
+use IteratorAggregate;
+
+interface TensorInterface extends ArrayAccess, Countable, IteratorAggregate
+{
+    public function shape(): array;
+
+    public function ndim(): int;
+
+    public function dtype(): DType;
+
+    public function buffer();
+
+    public function size(): int;
+
+    public static function fromArray(array $array, DType $dtype, array $shape): self;
+
+    public static function fromString(string $string, DType $dtype, array $shape): self;
+
+    public function toArray(): array;
+
+    public function toString(): string;
+}


### PR DESCRIPTION
## Description:

This PR addresses a previous issue(https://github.com/ankane/onnxruntime-php/issues/4) regarding some errors I encountered while using the library, and proposes  a new simple Tensor class. 

## Changes:

- **Tensor Class Implementation**: I have introduced a new Tensor class inspired by the Rindow Math Matrix library. This class utilizes an `SplFixedArray` as a 1-dimensional buffer and defines essential methods for working with tensors, including `shape()`, `size()`, and `dtype()`.
- **Interface for the Tensor**: I also included an interface to allow users possibly extend the tensor used and use their own custom tensors with more complicated implementations. 
- **Model Inputs Update:**: The model inputs to the InferenceSession have been updated to utilize the new `Tensor` class. There are convenient static methods in the `Tensor` class for converting multidimensional PHP arrays to tensors, with options for specifying data type and shape.

## Request for Feedback

I prioritized simplicity for end users while designing the class by avoiding the use of a shared buffer when iterating through tensors. While shared buffers can improve efficiency, they may introduce complexity for users not familiar with this concept.  Specifically, I would like to discuss whether to maintain the current simplistic approach or consider implementing that shared buffer functionality. 

